### PR TITLE
Include details in ProblemDetailsException

### DIFF
--- a/src/ProblemDetails/ProblemDetailsException.cs
+++ b/src/ProblemDetails/ProblemDetailsException.cs
@@ -1,14 +1,29 @@
 ﻿using System;
+using System.Text;
 
 namespace Hellang.Middleware.ProblemDetails
 {
     public class ProblemDetailsException : Exception
     {
         public ProblemDetailsException(Microsoft.AspNetCore.Mvc.ProblemDetails details)
+            :base($"{details.Type} : {details.Title}")
         {
             Details = details;
         }
 
         public Microsoft.AspNetCore.Mvc.ProblemDetails Details { get; }
+
+        public override string ToString()
+        {
+            var stringBuilder = new StringBuilder();
+
+            stringBuilder.AppendLine($"Type    : {Details.Type}");
+            stringBuilder.AppendLine($"Title   : {Details.Title}");
+            stringBuilder.AppendLine($"Status  : {Details.Status}");
+            stringBuilder.AppendLine($"Detail  : {Details.Detail}");
+            stringBuilder.AppendLine($"Instance: {Details.Instance}");
+
+            return stringBuilder.ToString();
+        }
     }
 }

--- a/test/ProblemDetails.Tests/ProblemDetailsExceptionTests.cs
+++ b/test/ProblemDetails.Tests/ProblemDetailsExceptionTests.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace Hellang.Middleware.ProblemDetails.Tests
+{
+    public class ProblemDetailsExceptionTests
+    {
+        private static Microsoft.AspNetCore.Mvc.ProblemDetails CreateProblemDetails()
+        {
+            return new Microsoft.AspNetCore.Mvc.ProblemDetails
+            {
+                Type = "https://httpstatuses.com/303",
+                Title = "See other",
+                Status = 303,
+                Detail = "Look somewhere else.",
+                Instance = "https://example.com/problem/123",
+            };
+
+        }
+
+        [Fact]
+        public void Constructor_InitializesMessage()
+        {
+            var problemDetails = CreateProblemDetails();
+
+            var exception = new ProblemDetailsException(problemDetails);
+
+            Assert.Equal("https://httpstatuses.com/303 : See other", exception.Message);
+        }
+
+        [Fact]
+        public void ToString_ReturnsAllDetails()
+        {
+            var problemDetails = CreateProblemDetails();
+
+            var exception = new ProblemDetailsException(problemDetails);
+            var actual = exception.ToString();
+
+            var expected = @"Type    : https://httpstatuses.com/303
+Title   : See other
+Status  : 303
+Detail  : Look somewhere else.
+Instance: https://example.com/problem/123
+";
+
+            Assert.Equal(expected, actual);
+        }
+    }
+}


### PR DESCRIPTION
As described in https://github.com/khellang/Middleware/issues/57, I initialize the `Message` property in the constructor and I override the `ToString()` method to have the full details. 

For a problem details that looks like: 
```json
{
  "type": "https://httpstatuses.com/303",
  "title": "See other",
  "status": 303,
  "detail": "Look somewhere else.",
  "instance": "https://example.com/problem/123"
}
```
The `exception.Message` returns: 
```
https://httpstatuses.com/303 : See other
```
While `exception.ToString()` returns:
```
Type    : https://httpstatuses.com/303
Title   : See other
Status  : 303
Detail  : Look somewhere else.
Instance: https://example.com/problem/123
```