### PR TITLE
Fix issue - ProblemDetails Content-Type incorrect when using ProducesAttribute

### DIFF
--- a/src/ProblemDetails/MediaTypeCollectionExtensions.cs
+++ b/src/ProblemDetails/MediaTypeCollectionExtensions.cs
@@ -1,0 +1,34 @@
+using System;
+using Microsoft.AspNetCore.Mvc.Formatters;
+
+namespace Hellang.Middleware.ProblemDetails
+{
+    /// <summary>
+    /// Extension methods for <see cref="MediaTypeCollection"/>
+    /// </summary>
+    public static class MediaTypeCollectionExtensions
+    {
+        /// <summary>
+        /// Creates a new <see cref="MediaTypeCollection"/> with the same items as an existing <see cref="MediaTypeCollection"/>
+        /// </summary>
+        /// <param name="mediaTypeCollection">The source <see cref="MediaTypeCollection"/> to copy items from</param>
+        /// <returns>A new <see cref="MediaTypeCollection"/></returns>
+        /// <exception cref="ArgumentNullException"></exception>
+        public static MediaTypeCollection Clone(this MediaTypeCollection mediaTypeCollection)
+        {
+            if (mediaTypeCollection == null)
+            {
+                throw new ArgumentNullException(nameof(mediaTypeCollection));
+            }
+
+            var clone = new MediaTypeCollection();
+
+            foreach (string mediaType in mediaTypeCollection)
+            {
+                clone.Add(mediaType);
+            }
+
+            return clone;
+        }
+    }
+}

--- a/src/ProblemDetails/Mvc/ProblemDetailsResultFilter.cs
+++ b/src/ProblemDetails/Mvc/ProblemDetailsResultFilter.cs
@@ -17,9 +17,9 @@ namespace Hellang.Middleware.ProblemDetails.Mvc
         }
 
         /// <summary>
-        /// The same order as the built-in ClientErrorResultFilter.
+        /// Order is set to 1 so that execution is after <see cref="ProducesAttribute"/>, which clears and sets ObjectResult.ContentTypes
         /// </summary>
-        public int Order => -2000;
+        public int Order => 1;
 
         private ProblemDetailsFactory Factory { get; }
 
@@ -90,11 +90,13 @@ namespace Hellang.Middleware.ProblemDetails.Mvc
         {
             Options.CallBeforeWriteHook(context.HttpContext, problemDetails);
 
-            return new ObjectResult(problemDetails)
+            var result = new ObjectResult(problemDetails)
             {
                 StatusCode = problemDetails.Status,
-                ContentTypes = Options.ContentTypes,
+                ContentTypes = Options.GetContentTypes()
             };
+
+            return result;
         }
     }
 }

--- a/src/ProblemDetails/Mvc/ProblemDetailsResultFilter.cs
+++ b/src/ProblemDetails/Mvc/ProblemDetailsResultFilter.cs
@@ -93,7 +93,7 @@ namespace Hellang.Middleware.ProblemDetails.Mvc
             var result = new ObjectResult(problemDetails)
             {
                 StatusCode = problemDetails.Status,
-                ContentTypes = Options.GetContentTypes()
+                ContentTypes = Options.ContentTypes.Clone()
             };
 
             return result;

--- a/src/ProblemDetails/ProblemDetails.csproj
+++ b/src/ProblemDetails/ProblemDetails.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.4.0</Version>
+    <Version>5.4.1</Version>
     <TargetFrameworks>netcoreapp3.1;net5.0</TargetFrameworks>
     <AssemblyName>Hellang.Middleware.ProblemDetails</AssemblyName>
     <RootNamespace>Hellang.Middleware.ProblemDetails</RootNamespace>

--- a/src/ProblemDetails/ProblemDetailsMiddleware.cs
+++ b/src/ProblemDetails/ProblemDetailsMiddleware.cs
@@ -136,7 +136,7 @@ namespace Hellang.Middleware.ProblemDetails
             var result = new ObjectResult(details)
             {
                 StatusCode = details.Status ?? context.Response.StatusCode,
-                ContentTypes = Options.GetContentTypes(),
+                ContentTypes = Options.ContentTypes.Clone(),
             };
 
             await Executor.ExecuteAsync(actionContext, result);

--- a/src/ProblemDetails/ProblemDetailsMiddleware.cs
+++ b/src/ProblemDetails/ProblemDetailsMiddleware.cs
@@ -136,7 +136,7 @@ namespace Hellang.Middleware.ProblemDetails
             var result = new ObjectResult(details)
             {
                 StatusCode = details.Status ?? context.Response.StatusCode,
-                ContentTypes = Options.ContentTypes,
+                ContentTypes = Options.GetContentTypes(),
             };
 
             await Executor.ExecuteAsync(actionContext, result);

--- a/src/ProblemDetails/ProblemDetailsOptions.cs
+++ b/src/ProblemDetails/ProblemDetailsOptions.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using Microsoft.AspNetCore.Http;
-using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.FileProviders;
 using Microsoft.Extensions.Hosting;
@@ -20,7 +19,7 @@ namespace Hellang.Middleware.ProblemDetails
             SourceCodeLineCount = 6;
             Mappers = new List<ExceptionMapper>();
             RethrowPolicies = new List<Func<HttpContext, Exception, bool>>();
-            ContentTypes = new List<MediaTypeHeaderValue>();
+            ContentTypes = new MediaTypeCollection();
             ExceptionDetailsPropertyName = DefaultExceptionDetailsPropertyName;
             ValidationProblemStatusCode = StatusCodes.Status422UnprocessableEntity;
             AllowedHeaderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -121,7 +120,7 @@ namespace Hellang.Middleware.ProblemDetails
         /// Gets the supported <c>Content-Type</c> values for use in content negotiation.
         /// The default values are <c>application/problem+json</c> and <c>application/problem+xml</c>.
         /// </summary>
-        public IList<MediaTypeHeaderValue> ContentTypes { get; }
+        public MediaTypeCollection ContentTypes { get; }
 
         /// <summary>
         /// Gets or sets the status code used for validation errors when using the MVC conventions.
@@ -131,24 +130,6 @@ namespace Hellang.Middleware.ProblemDetails
         private List<ExceptionMapper> Mappers { get; }
 
         private List<Func<HttpContext, Exception, bool>> RethrowPolicies { get; }
-
-        /// <summary>
-        /// Creates a new <see cref="MediaTypeCollection"/> containing all the <see cref="MediaTypeHeaderValue"/> in <see cref="ContentTypes"/>
-        /// </summary>
-        /// <returns>A <see cref="MediaTypeCollection"/> with default values of <c>application/problem+json</c> and <c>application/problem+xml</c></returns>
-        /// <remarks>Partial fix for https://github.com/khellang/Middleware/issues/137
-        /// Creating a new collection each time avoids the possibility of a global ContentTypes collection being poisoned by <see cref="ProducesAttribute"/></remarks>
-        public MediaTypeCollection GetContentTypes()
-        {
-            var collection = new MediaTypeCollection();
-
-            foreach (MediaTypeHeaderValue contentType in ContentTypes)
-            {
-                collection.Add(contentType);
-            }
-
-            return collection;
-        }
 
         /// <summary>
         /// Maps the specified exception type <typeparamref name="TException"/> to the specified

--- a/src/ProblemDetails/ProblemDetailsOptions.cs
+++ b/src/ProblemDetails/ProblemDetailsOptions.cs
@@ -20,7 +20,7 @@ namespace Hellang.Middleware.ProblemDetails
             SourceCodeLineCount = 6;
             Mappers = new List<ExceptionMapper>();
             RethrowPolicies = new List<Func<HttpContext, Exception, bool>>();
-            ContentTypes = new MediaTypeCollection();
+            ContentTypes = new List<MediaTypeHeaderValue>();
             ExceptionDetailsPropertyName = DefaultExceptionDetailsPropertyName;
             ValidationProblemStatusCode = StatusCodes.Status422UnprocessableEntity;
             AllowedHeaderNames = new HashSet<string>(StringComparer.OrdinalIgnoreCase)
@@ -121,7 +121,7 @@ namespace Hellang.Middleware.ProblemDetails
         /// Gets the supported <c>Content-Type</c> values for use in content negotiation.
         /// The default values are <c>application/problem+json</c> and <c>application/problem+xml</c>.
         /// </summary>
-        public MediaTypeCollection ContentTypes { get; }
+        public IList<MediaTypeHeaderValue> ContentTypes { get; }
 
         /// <summary>
         /// Gets or sets the status code used for validation errors when using the MVC conventions.
@@ -131,6 +131,24 @@ namespace Hellang.Middleware.ProblemDetails
         private List<ExceptionMapper> Mappers { get; }
 
         private List<Func<HttpContext, Exception, bool>> RethrowPolicies { get; }
+
+        /// <summary>
+        /// Creates a new <see cref="MediaTypeCollection"/> containing all the <see cref="MediaTypeHeaderValue"/> in <see cref="ContentTypes"/>
+        /// </summary>
+        /// <returns>A <see cref="MediaTypeCollection"/> with default values of <c>application/problem+json</c> and <c>application/problem+xml</c></returns>
+        /// <remarks>Partial fix for https://github.com/khellang/Middleware/issues/137
+        /// Creating a new collection each time avoids the possibility of a global ContentTypes collection being poisoned by <see cref="ProducesAttribute"/></remarks>
+        public MediaTypeCollection GetContentTypes()
+        {
+            var collection = new MediaTypeCollection();
+
+            foreach (MediaTypeHeaderValue contentType in ContentTypes)
+            {
+                collection.Add(contentType);
+            }
+
+            return collection;
+        }
 
         /// <summary>
         /// Maps the specified exception type <typeparamref name="TException"/> to the specified

--- a/test/ProblemDetails.Tests/ProblemDetailsMiddlewareTests.cs
+++ b/test/ProblemDetails.Tests/ProblemDetailsMiddlewareTests.cs
@@ -125,7 +125,7 @@ namespace ProblemDetails.Tests
             void Configure(ProblemDetailsOptions options)
             {
                 options.ContentTypes.Clear();
-                options.ContentTypes.Add(MediaTypeHeaderValue.Parse(optionsContentType));
+                options.ContentTypes.Add(optionsContentType);
                 options.Map<Exception>(_ => new MvcProblemDetails());
             }
 

--- a/test/ProblemDetails.Tests/ProblemDetailsMiddlewareTests.cs
+++ b/test/ProblemDetails.Tests/ProblemDetailsMiddlewareTests.cs
@@ -125,7 +125,7 @@ namespace ProblemDetails.Tests
             void Configure(ProblemDetailsOptions options)
             {
                 options.ContentTypes.Clear();
-                options.ContentTypes.Add(optionsContentType);
+                options.ContentTypes.Add(MediaTypeHeaderValue.Parse(optionsContentType));
                 options.Map<Exception>(_ => new MvcProblemDetails());
             }
 


### PR DESCRIPTION
Resolves #137 
(Incorrect Content-Type when using ProducesAttribute, ProblemDetailsResultFilter and ObjectResult with Status >= 400)

- Edit `ProblemDetailsResultFilter.Order` to be greater than the default of zero used by ProducesAttribute. This avoids ProducesAttribute resetting ObjectResult.ContentTypes
- `MediaTypeCollectionExtensions.Clone` extension method added to be used when assigning ContentTypes to an ObjectResult, to avoid ProblemDetailsOptions.ContentTypes being accidentally edited