### PR TITLE
Change default exception details property name

### DIFF
--- a/src/ProblemDetails/ProblemDetailsOptions.cs
+++ b/src/ProblemDetails/ProblemDetailsOptions.cs
@@ -13,7 +13,7 @@ namespace Hellang.Middleware.ProblemDetails
 {
     public class ProblemDetailsOptions
     {
-        public const string DefaultExceptionDetailsPropertyName = "errors";
+        public const string DefaultExceptionDetailsPropertyName = "exceptionDetails";
 
         public ProblemDetailsOptions()
         {

--- a/test/ProblemDetails.Tests/ProblemDetailsMiddlewareTests.cs
+++ b/test/ProblemDetails.Tests/ProblemDetailsMiddlewareTests.cs
@@ -240,7 +240,7 @@ namespace ProblemDetails.Tests
 
             var content = await response.Content.ReadFromJsonAsync<MvcProblemDetails>();
 
-            Assert.Equal(expectExceptionDetails, content.Extensions.ContainsKey("exceptionDetails"));
+            Assert.Equal(expectExceptionDetails, content.Extensions.ContainsKey(ProblemDetailsOptions.DefaultExceptionDetailsPropertyName));
         }
 
         [Fact]
@@ -517,7 +517,7 @@ namespace ProblemDetails.Tests
 
             if (expectExceptionDetails)
             {
-                Assert.True(content.Extensions.ContainsKey("exceptionDetails"), "Expected response to contain exception details.");
+                Assert.True(content.Extensions.ContainsKey(ProblemDetailsOptions.DefaultExceptionDetailsPropertyName), "Expected response to contain exception details.");
             }
 
             Assert.Contains(nameof(ProblemDetailsOptions.OnBeforeWriteDetails), content.Extensions.Keys);

--- a/test/ProblemDetails.Tests/ProblemDetailsMiddlewareTests.cs
+++ b/test/ProblemDetails.Tests/ProblemDetailsMiddlewareTests.cs
@@ -240,7 +240,7 @@ namespace ProblemDetails.Tests
 
             var content = await response.Content.ReadFromJsonAsync<MvcProblemDetails>();
 
-            Assert.Equal(expectExceptionDetails, content.Extensions.ContainsKey("errors"));
+            Assert.Equal(expectExceptionDetails, content.Extensions.ContainsKey("exceptionDetails"));
         }
 
         [Fact]
@@ -517,7 +517,7 @@ namespace ProblemDetails.Tests
 
             if (expectExceptionDetails)
             {
-                Assert.True(content.Extensions.ContainsKey("errors"), "Expected response to contain exception details.");
+                Assert.True(content.Extensions.ContainsKey("exceptionDetails"), "Expected response to contain exception details.");
             }
 
             Assert.Contains(nameof(ProblemDetailsOptions.OnBeforeWriteDetails), content.Extensions.Keys);


### PR DESCRIPTION
Fixes #102

Exception details share the same JSON property name `"errors"` as validation errors, except as an array instead of a JSON object.
This causes problems with libraries like [Refit](https://github.com/reactiveui/refit), where it no longer is able to deserialize the `ProblemDetails` object and throws an `Refit.ApiException` instead of `Refit.ValidationApiException`.

Exception details is enabled when running in `Development` environment, by default.

### Changes
- Change `DefaultExceptionDetailsPropertyName` from `errors` to `exceptionDetails`
 
### Testing
- Refit throws `Refit.ValidationApiException` and is able to deserialize the `ProblemDetails` object.