### PR TITLE
replace httpstatuses.com with httpstatuses.io

### DIFF
--- a/src/ProblemDetails/StatusCodeProblemDetails.cs
+++ b/src/ProblemDetails/StatusCodeProblemDetails.cs
@@ -41,7 +41,7 @@ namespace Hellang.Middleware.ProblemDetails
 
         internal static string GetDefaultType(int statusCode)
         {
-            return $"https://httpstatuses.com/{statusCode}";
+            return $"https://httpstatuses.io/{statusCode}";
         }
     }
 }

--- a/test/ProblemDetails.Tests/ProblemDetailsExceptionTests.cs
+++ b/test/ProblemDetails.Tests/ProblemDetailsExceptionTests.cs
@@ -14,7 +14,7 @@ namespace ProblemDetails.Tests
 
             var exception = new ProblemDetailsException(problemDetails);
 
-            Assert.Equal("https://httpstatuses.com/303 : See other", exception.Message);
+            Assert.Equal("https://httpstatuses.io/303 : See other", exception.Message);
         }
 
         [Fact]
@@ -25,7 +25,7 @@ namespace ProblemDetails.Tests
             var exception = new ProblemDetailsException(problemDetails);
             var actual = exception.ToString();
 
-            var expected = @"Type    : https://httpstatuses.com/303
+            var expected = @"Type    : https://httpstatuses.io/303
 Title   : See other
 Status  : 303
 Detail  : Look somewhere else.
@@ -83,7 +83,7 @@ Instance: https://example.com/problem/123
         {
             return new Microsoft.AspNetCore.Mvc.ProblemDetails
             {
-                Type = "https://httpstatuses.com/303",
+                Type = "https://httpstatuses.io/303",
                 Title = "See other",
                 Status = 303,
                 Detail = "Look somewhere else.",

--- a/test/ProblemDetails.Tests/ProblemDetailsMiddlewareTests.cs
+++ b/test/ProblemDetails.Tests/ProblemDetailsMiddlewareTests.cs
@@ -148,7 +148,7 @@ namespace ProblemDetails.Tests
             var details = new MvcProblemDetails
             {
                 Title = ReasonPhrases.GetReasonPhrase(expected),
-                Type = $"https://httpstatuses.com/{expected}",
+                Type = $"https://httpstatuses.io/{expected}",
                 Status = expected,
             };
 
@@ -171,7 +171,7 @@ namespace ProblemDetails.Tests
             var details = new MvcProblemDetails
             {
                 Title = ReasonPhrases.GetReasonPhrase(expected),
-                Type = $"https://httpstatuses.com/{expected}",
+                Type = $"https://httpstatuses.io/{expected}",
                 Status = expected,
             };
 


### PR DESCRIPTION
https://httpstatuses.com was taken down in early 2022 per https://jkulton.com/2022/reviving-httpstatuses.

This replaces https://httpstatuses.com with https://httpstatuses.io which presents the route structure and information.

The new https://httpstatuses.io website source code is located at https://github.com/httpstatuses/httpstatuses.