### PR TITLE
Add the possibility to chose whether to handle the exception or not

### DIFF
--- a/src/ProblemDetails/ProblemDetailsMiddleware.cs
+++ b/src/ProblemDetails/ProblemDetailsMiddleware.cs
@@ -65,6 +65,11 @@ namespace Hellang.Middleware.ProblemDetails
             }
             catch (Exception ex)
             {
+                if (!Options.HandleException(context, ex))
+                {
+                    throw;
+                }
+
                 edi = ExceptionDispatchInfo.Capture(ex);
             }
 

--- a/src/ProblemDetails/ProblemDetailsOptions.cs
+++ b/src/ProblemDetails/ProblemDetailsOptions.cs
@@ -65,6 +65,12 @@ namespace Hellang.Middleware.ProblemDetails
         public Func<HttpContext, Exception, bool> IncludeExceptionDetails { get; set; } = null!;
 
         /// <summary>
+        /// Gets or sets the predicate used for determining the exception is handled or forwarded to the next middleware.
+        /// The default returns <c>true</c>.
+        /// </summary>
+        public Func<HttpContext, Exception, bool> HandleException { get; set; } = null!;
+
+        /// <summary>
         /// The property name to use for traceId
         /// This defaults to <see cref="DefaultTraceIdPropertyName"/> (<c>traceId</c>).
         /// </summary>

--- a/src/ProblemDetails/ProblemDetailsOptionsSetup.cs
+++ b/src/ProblemDetails/ProblemDetailsOptionsSetup.cs
@@ -12,6 +12,11 @@ namespace Hellang.Middleware.ProblemDetails
     {
         public void Configure(ProblemDetailsOptions options)
         {
+            if (options.HandleException is null)
+            {
+                options.HandleException = (ctx, e) => true;
+            }
+
             if (options.IncludeExceptionDetails is null)
             {
                 options.IncludeExceptionDetails = IncludeExceptionDetails;


### PR DESCRIPTION
This change add the possibility to forward the not handled exception to the net middleware, if we don't want problemDetails Object result, for example to let the "Developer Exception Page" display the details.