### PR TITLE
Revert "Use existing MVC object result executor instead of Minimal API-based one"

### DIFF
--- a/src/ProblemDetails/MinimalApiResultExecutor.cs
+++ b/src/ProblemDetails/MinimalApiResultExecutor.cs
@@ -1,0 +1,16 @@
+#if NET6_0_OR_GREATER
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Infrastructure;
+using System.Threading.Tasks;
+
+namespace Hellang.Middleware.ProblemDetails
+{
+    internal class MinimalApiResultExecutor : IActionResultExecutor<ObjectResult>
+    {
+        public Task ExecuteAsync(ActionContext context, ObjectResult result) =>
+            Results.Json(result.Value, options: null, "application/problem+json", result.StatusCode)
+                .ExecuteAsync(context.HttpContext);
+    }
+}
+#endif

--- a/src/ProblemDetails/ProblemDetailsExtensions.cs
+++ b/src/ProblemDetails/ProblemDetailsExtensions.cs
@@ -37,8 +37,11 @@ namespace Hellang.Middleware.ProblemDetails
 
             services.TryAddSingleton<LibProblemDetailsFactory>();
             services.TryAddSingleton<ProblemDetailsMarkerService, ProblemDetailsMarkerService>();
-            services.TryAddSingleton<IActionResultExecutor<ObjectResult>, ObjectResultExecutor>();
             services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<ProblemDetailsOptions>, ProblemDetailsOptionsSetup>());
+
+#if NET6_0_OR_GREATER
+            services.TryAddSingleton<IActionResultExecutor<ObjectResult>, MinimalApiResultExecutor>();
+#endif
 
             return services;
         }


### PR DESCRIPTION
Resolving #182 by reverting commit 1857120a.
`ProblemDetails` does not resolve `ObjectResultExecutor` in .Net 6 as it doesn't have the required dependencies that are normally added in traditional controller setups. 