### PR TITLE
feat(ProblemDetails): Allow filtering properties (Detail, ExceptionDetails) #194

### DIFF
--- a/samples/ProblemDetails.Sample/Program.cs
+++ b/samples/ProblemDetails.Sample/Program.cs
@@ -66,6 +66,11 @@ namespace Hellang.Middleware.ProblemDetails.Sample
             // Only include exception details in a development environment. There's really no need
             // to set this as it's the default behavior. It's just included here for completeness :)
             options.IncludeExceptionDetails = (ctx, ex) => Environment.IsDevelopment();
+            options.IncludePropsFilter = (context, exception) => new IncludeProblemDetailProps()
+            {
+                Detail = true,
+                ExceptionDetails = true
+            };
 
             // Custom mapping function for FluentValidation's ValidationException.
             options.MapFluentValidationException();

--- a/src/ProblemDetails/DeveloperProblemDetailsExtensions.cs
+++ b/src/ProblemDetails/DeveloperProblemDetailsExtensions.cs
@@ -11,13 +11,22 @@ namespace Hellang.Middleware.ProblemDetails
 {
     internal static class DeveloperProblemDetailsExtensions
     {
-        public static MvcProblemDetails WithExceptionDetails(this MvcProblemDetails problem, string propertyName, Exception error, IEnumerable<ExceptionDetails> details)
+        public static MvcProblemDetails WithExceptionDetails(this MvcProblemDetails problem, string propertyName, Exception error, IEnumerable<ExceptionDetails> details, IncludeProblemDetailProps includeProps)
         {
             problem.Title ??= TypeNameHelper.GetTypeDisplayName(error.GetType());
-            problem.Extensions[propertyName] = GetErrors(details).ToList();
+
+            if (includeProps.ExceptionDetails)
+            {
+                problem.Extensions[propertyName] = GetErrors(details).ToList();
+            }
+
             problem.Status ??= StatusCodes.Status500InternalServerError;
             problem.Instance ??= GetHelpLink(error);
-            problem.Detail ??= error.Message;
+            if (includeProps.Detail)
+            {
+                problem.Detail ??= error.Message;
+            }
+
             return problem;
         }
 

--- a/src/ProblemDetails/IncludeProblemDetailProps.cs
+++ b/src/ProblemDetails/IncludeProblemDetailProps.cs
@@ -1,0 +1,19 @@
+namespace Hellang.Middleware.ProblemDetails
+{
+    /// <summary>
+    /// Properties to include in ProblemDetails.
+    /// By default, all properties are false and will not be included.
+    /// </summary>
+    public class IncludeProblemDetailProps
+    {
+        /// <summary>
+        /// Include the Exception Details Stack
+        /// </summary>
+        public bool ExceptionDetails { get; set; }
+
+        /// <summary>
+        /// Include the Detail summary property
+        /// </summary>
+        public bool Detail { get; set; }
+    }
+}

--- a/src/ProblemDetails/ProblemDetailsFactory.cs
+++ b/src/ProblemDetails/ProblemDetailsFactory.cs
@@ -61,12 +61,16 @@ namespace Hellang.Middleware.ProblemDetails
                 }
             }
 
-            if (Options.IncludeExceptionDetails(context, error))
+            var includePropsFilter = Options.IncludePropsFilter?.Invoke(context, error);
+
+            if (Options.IncludeExceptionDetails(context, error) || includePropsFilter is not null)
             {
                 try
                 {
+                    includePropsFilter ??= new IncludeProblemDetailProps{ExceptionDetails = true, Detail = true};
                     // Instead of returning a new object, we mutate the existing problem so users keep all details.
-                    return result.WithExceptionDetails(Options.ExceptionDetailsPropertyName, error, DetailsProvider.GetDetails(error));
+                    return result.WithExceptionDetails(Options.ExceptionDetailsPropertyName, error,
+                        DetailsProvider.GetDetails(error), includePropsFilter);
                 }
                 catch (Exception e)
                 {

--- a/src/ProblemDetails/ProblemDetailsOptions.cs
+++ b/src/ProblemDetails/ProblemDetailsOptions.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Reflection;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc.Formatters;
 using Microsoft.Extensions.FileProviders;
@@ -63,6 +64,13 @@ namespace Hellang.Middleware.ProblemDetails
         /// The default returns <c>true</c> when <see cref="IHostEnvironment.EnvironmentName"/> is "Development".
         /// </summary>
         public Func<HttpContext, Exception, bool> IncludeExceptionDetails { get; set; } = null!;
+
+        /// <summary>
+        /// Configure which properties to include in the problem details response.
+        /// By default all fields are excluded.
+        /// This can be used as an alternative to <see cref="IncludeExceptionDetails"/> when specific fields are needed.
+        /// </summary>
+        public Func<HttpContext, Exception, IncludeProblemDetailProps>? IncludePropsFilter { get; set; } = null!;
 
         /// <summary>
         /// The property name to use for traceId


### PR DESCRIPTION
Allow option to filter ProblemDetails property to independently include/exclude Detail, ExceptionDetails
* Shouldn't break existing API

Could replace `options.IncludeExceptionDetails`, as can achieve the same thing, but was left to avoid breaking change.

Not totally happy with the API, please provide input.
Another option considered was similar to `AllowedHeaderNames` having a HashSet of string props that are allowed in the ProblemDetail response ?

Assists to resolve #194