### PR TITLE
Added overwritting default exception logging mechanism

### DIFF
--- a/src/ProblemDetails/ProblemDetailsMiddleware.cs
+++ b/src/ProblemDetails/ProblemDetailsMiddleware.cs
@@ -118,7 +118,14 @@ namespace Hellang.Middleware.ProblemDetails
                 {
                     if (Options.ShouldLogUnhandledException(context, error, details))
                     {
-                        Logger.UnhandledException(error);
+                        if (Options.OnLogUnhandledException != null)
+                        {
+                            Options.OnLogUnhandledException(context, error, details);
+                        }
+                        else
+                        {
+                            Logger.UnhandledException(error);
+                        }
                     }
 
                     await WriteProblemDetails(context, details);

--- a/src/ProblemDetails/ProblemDetailsOptions.cs
+++ b/src/ProblemDetails/ProblemDetailsOptions.cs
@@ -114,6 +114,11 @@ namespace Hellang.Middleware.ProblemDetails
         public Func<HttpContext, Exception, MvcProblemDetails, bool> ShouldLogUnhandledException { get; set; } = null!;
 
         /// <summary>
+        /// Gets or sets a callback used to overwrite the default unhandled exception logging method.
+        /// </summary>
+        public Action<HttpContext, Exception, MvcProblemDetails>? OnLogUnhandledException { get; set; }
+
+        /// <summary>
         /// Gets or sets an action to populate response cache headers to prevent caching problem details responses.
         /// </summary>
         public Action<HttpContext, HeaderDictionary> AppendCacheHeaders { get; set; } = null!;


### PR DESCRIPTION
The idea behind the PR is to allow developers to define their own logging mechanism for unhandled exceptions. 
If none are defined, the middleware shall default to the same behavior as before.

Implemented as a response to: #205 